### PR TITLE
fix(rules): remove space before parens rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ module.exports = {
     'no-alert': 'error',
     'no-console': 'error',
     'no-underscore-dangle': 'off',
-    'space-before-function-paren': ['error', 'always'],
     'padded-blocks': 'error',
     semi: ['error', 'never'],
     quotes: ['error', 'single'],


### PR DESCRIPTION
Aligning this with WIP prettier rollout & telus standard (see https://github.com/telus/telus-standard/commit/7de62d4d2cd13a3f11620e8654d818b698bb1228)